### PR TITLE
Fix AWS CIS 1.14

### DIFF
--- a/policy.hcl
+++ b/policy.hcl
@@ -126,11 +126,10 @@ policy "cis-v1.20" {
 
     query "1.14" {
       description = "AWS CIS 1.14 Ensure hardware MFA is enabled for the 'root' account (Scored)"
-      expect_output = true
       query =<<EOF
-      SELECT aiu.account_id, arn, password_last_used, aiu.user_name, mfa_active FROM aws_iam_users as aiu
-      JOIN aws_iam_virtual_mfa_devices ON aws_iam_virtual_mfa_devices.user_arn = aiu.arn
-      WHERE aiu.user_name = '<root_account>' AND aiu.mfa_active
+      SELECT aiu.account_id, arn, max(password_last_used) as password_last_used  FROM aws_iam_users as aiu
+      LEFT JOIN aws_iam_virtual_mfa_devices ON aws_iam_virtual_mfa_devices.user_arn = aiu.arn
+      WHERE aiu.user_name = '<root_account>' AND aiu.mfa_active = false group by aiu.account_id, arn
     EOF
     }
 

--- a/policy.hcl
+++ b/policy.hcl
@@ -127,9 +127,9 @@ policy "cis-v1.20" {
     query "1.14" {
       description = "AWS CIS 1.14 Ensure hardware MFA is enabled for the 'root' account (Scored)"
       query =<<EOF
-      SELECT aiu.account_id, arn, max(password_last_used) as password_last_used  FROM aws_iam_users as aiu
+      SELECT aiu.account_id, arn, max(password_last_used) as password_last_used FROM aws_iam_users as aiu
       LEFT JOIN aws_iam_virtual_mfa_devices ON aws_iam_virtual_mfa_devices.user_arn = aiu.arn
-      WHERE aiu.user_name = '<root_account>' AND aiu.mfa_active = false group by aiu.account_id, arn
+      WHERE aiu.user_name = '<root_account>' AND (serial_number IS NULL or aiu.mfa_active = false) group by aiu.account_id, arn
     EOF
     }
 


### PR DESCRIPTION
Find all root accounts that Have a Virtual MFA.

I had to invert the query. So anytime there is a response it should fail. There was no way I could structure the query so that we could support multiple AWS accounts in a single database

This fixes #16 